### PR TITLE
build: auto set alias on docs.clouway.com after merge on master

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "name": "docs",
+  "alias": ["docs.clouway.com"],
   "builds": [
     {
       "src": "package.json",


### PR DESCRIPTION
The alias of docs.clouway.com is now automatically set after merging with master.


```
If an alias is set within the now.json file, pushes and merges to the default branch (commonly "master") will be aliased automatically and made live to those aliases with the latest deployment made with a push.
```