### PR TITLE
i18n: remove warnings for unknown pages

### DIFF
--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -5,6 +5,10 @@ import Link from 'gatsby-link'
 import {withTranslation} from 'react-i18next'
 
 const LinkWrapper = ({t, to, tReady, i18n, defaultNS, ...props}) => {
+  if (!i18n.language) {
+    return null
+  }
+
   if (to.startsWith(`/${i18n.language}`)) {
     return <Link to={to} {...props} />
   }


### PR DESCRIPTION
This is due to `undefined` language in our LinkWrapper component.