### PR TITLE
i18n: render simple anchor when i18n is not ready

### DIFF
--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -6,7 +6,7 @@ import {withTranslation} from 'react-i18next'
 
 const LinkWrapper = ({t, to, tReady, i18n, defaultNS, ...props}) => {
   if (!i18n.language) {
-    return null
+    return <a {...props} />
   }
 
   if (to.startsWith(`/${i18n.language}`)) {


### PR DESCRIPTION
This will remove the flickering for the rendered links. This is due to async loading of i18next.  Now, we are rendering simple anchor when the lang is not found.