### PR TITLE
docs/politis: add english version of introduction and quick_start pages

### DIFF
--- a/src/pages/politis/get-started/introduction.en.md
+++ b/src/pages/politis/get-started/introduction.en.md
@@ -1,0 +1,14 @@
+---
+date: "2019-07-20"
+title: Introduction
+root: "/politis"
+parents: ["Home"]
+priority: 1
+---
+<h1 align="center">
+  Introduction
+</h1>
+
+### Introduction
+
+Coming Soon.

--- a/src/pages/politis/get-started/quick_start.en.md
+++ b/src/pages/politis/get-started/quick_start.en.md
@@ -1,0 +1,34 @@
+---
+date: "2019-07-20"
+title: Getting Started
+root: "/politis"
+parents: ["Home"]
+priority: 2
+---
+<h1 align="center">
+  Getting Started
+</h1>
+
+## Products
+
+Coming soon.
+
+## Warehouse
+
+Coming soon.
+
+## Documents
+
+Coming soon.
+
+#### Purchase
+
+Coming soon.
+
+#### Transfer
+
+Coming soon.
+
+#### Sale
+
+Coming soon.


### PR DESCRIPTION
Added English version of introduction page.
Added English version of quick_start page.

![Screenshot_20190730_094446](https://user-images.githubusercontent.com/2754552/62106775-c3c48280-b2ae-11e9-906e-3077f1154586.png)