### PR TITLE
docs/navigate: doesn't nav to lang when lang is already set

### DIFF
--- a/src/components/Layout/I18N.js
+++ b/src/components/Layout/I18N.js
@@ -30,6 +30,10 @@ class I18N extends React.Component {
   handleLanguageChanged = lng => {
     const {navigate, location} = this.props
 
+    if (location.pathname.startsWith(`/${lng}`)) {
+      return
+    }
+
     const parts = location.pathname.split('/')
 
     parts[1] = lng


### PR DESCRIPTION
Does not navigate to lang (/en, /bg, etc.) when the lang is already set in the url (e.g. /bg/fleerp/etc)

fixes #52